### PR TITLE
tmx: add omitempty tag to omit optional fields when outputting XML

### DIFF
--- a/data.go
+++ b/data.go
@@ -21,7 +21,7 @@ type Data struct {
 	Encoding string `xml:"encoding,attr"`
 	// Compression is the compression used for the data. It can either be
 	// "gzip" or "zlib"
-	Compression string `xml:"compression,attr"`
+	Compression string `xml:"compression,attr,omitempty"`
 	// Tiles are the tiles in the data. Not the same as TMXTiles from the Tileset.
 	Tiles []TileData `xml:"tile"`
 	// Chunks are sets of tiles over an area. Used for randomly generated maps.

--- a/layer.go
+++ b/layer.go
@@ -7,9 +7,9 @@ type Layer struct {
 	// Name is the name of the layer
 	Name string `xml:"name,attr"`
 	// X is the x coordinate of the layer
-	X float64 `xml:"x,attr"`
+	X float64 `xml:"x,attr,omitempty"`
 	// Y is the y coordinate of the layer
-	Y float64 `xml:"y,attr"`
+	Y float64 `xml:"y,attr,omitempty"`
 	// Width is the width of the layer in tiles. Always the same as the map
 	// width for fixed-size maps.
 	Width int `xml:"width,attr"`
@@ -21,11 +21,11 @@ type Layer struct {
 	// Visible is whether the layer is shown(1) or hidden(0). Defaults to 1.
 	Visible int `xml:"visible,attr"`
 	// OffsetX is the rendering offset for this layer in pixels.
-	OffsetX float64 `xml:"offsetx,attr"`
+	OffsetX float64 `xml:"offsetx,attr,omitempty"`
 	// OffsetY is the rendering offset for this layer in pixels.
-	OffsetY float64 `xml:"offsety,attr"`
+	OffsetY float64 `xml:"offsety,attr,omitempty"`
 	// Properties are the properties of the layer
-	Properties []Property `xml:"properties>property"`
+	Properties []Property `xml:"properties,omitempty>property"`
 	// Data is any data for the layer
 	Data []Data `xml:"data"`
 }

--- a/map.go
+++ b/map.go
@@ -4,10 +4,12 @@ import "encoding/xml"
 
 // Map is the root element of a TMX map
 type Map struct {
+	// Indicate to encoding/xml that the <map> tag should be lowercase.
+	XMLName string `xml:"map"`
 	// Version is the TMX format version
-	Version string `xml:"version,attr"`
+	Version string `xml:"version,attr,omitempty"`
 	// TiledVersion is the Version of Tiled Map Editor used to generate the TMX
-	TiledVersion string `xml:"tiledversion,attr"`
+	TiledVersion string `xml:"tiledversion,attr,omitempty"`
 	// Orientation is the orientation of the map. Tiled supports “orthogonal”,
 	// “isometric”, “staggered” and “hexagonal”
 	Orientation string `xml:"orientation,attr"`
@@ -15,7 +17,7 @@ type Map struct {
 	// Valid values are right-down (the default), right-up, left-down and left-up.
 	// In all cases, the map is drawn row-by-row.
 	// (only supported for orthogonal maps at the moment)
-	RenderOrder string `xml:"renderorder,attr"`
+	RenderOrder string `xml:"renderorder,attr,omitempty"`
 	// Width is the map width in tiles
 	Width int `xml:"width,attr"`
 	// Height is the map height in tiles
@@ -26,19 +28,19 @@ type Map struct {
 	TileHeight int `xml:"tileheight,attr"`
 	// HexSideLength determines the width or height (depending on the staggered
 	// axis) of the tile’s edge, in pixels. Only for hexagonal maps.
-	HexSideLength int `xml:"hexsidelength,attr"`
+	HexSideLength int `xml:"hexsidelength,attr,omitempty"`
 	// StaggerAxis is for staggered and hexagonal maps, determines which axis
 	// (“x” or “y”) is staggered.
-	StaggerAxis string `xml:"staggeraxis,attr"`
+	StaggerAxis string `xml:"staggeraxis,attr,omitempty"`
 	// StaggerIndex is for staggered and hexagonal maps, determines whether the
 	// “even” or “odd” indexes along the staggered axis are shifted.
-	StaggerIndex string `xml:"staggerindex,attr"`
+	StaggerIndex string `xml:"staggerindex,attr,omitempty"`
 	// BackgroundColor is the background color of the map. Is of the form #AARRGGBB
-	BackgroundColor string `xml:"backgroundcolor,attr"`
+	BackgroundColor string `xml:"backgroundcolor,attr,omitempty"`
 	// NextObjectID stores the next object id available for new objects.
-	NextObjectID int `xml:"nextobjectid,attr"`
+	NextObjectID int `xml:"nextobjectid,attr,omitempty"`
 	// Properties are the properties of the map
-	Properties []Property `xml:"properties>property"`
+	Properties []Property `xml:"properties,omitempty>property"`
 	// Tilesets are the tilesets of the map
 	Tilesets []Tileset `xml:"tileset"`
 	// Layers are the layers of the map

--- a/tileset.go
+++ b/tileset.go
@@ -13,7 +13,7 @@ type Tileset struct {
 	// to the first tile in this tileset)
 	FirstGID uint32 `xml:"firstgid,attr"`
 	// Source is the location of the external tilemap TSX file, if any
-	Source string `xml:"source,attr"`
+	Source string `xml:"source,attr,omitempty"`
 	// Name is the name of the tileset
 	Name string `xml:"name,attr"`
 	// TileWidth is the (maximum) width of tiles in the tileset
@@ -21,13 +21,13 @@ type Tileset struct {
 	// TileHeight is the (maximum) height of the tiles in the tileset
 	TileHeight int `xml:"tileheight,attr"`
 	// Spacing is the spacing of the tiles in pixels between the tiles in the tileset
-	Spacing int `xml:"spacing,attr"`
+	Spacing int `xml:"spacing,attr,omitempty"`
 	// Margin is the margin around the tiles in pixels of the tiles in the tileset
-	Margin float64 `xml:"margin,attr"`
+	Margin float64 `xml:"margin,attr,omitempty"`
 	// TileCount is the number of tiles in the tileset
-	TileCount int `xml:"tilecount,attr"`
+	TileCount int `xml:"tilecount,attr,omitempty"`
 	// Columns is the number of tile columns in the tileset
-	Columns int `xml:"columns,attr"`
+	Columns int `xml:"columns,attr,omitempty"`
 	// TileOffset is used to specify an offset in pixels, to be applied when
 	// drawing a tile from the related tileset. When not present, no offset
 	// is applied
@@ -36,15 +36,15 @@ type Tileset struct {
 	// tile overlays for terrain and collision information are rendered
 	Grid []Grid `xml:"grid"`
 	// Properties are the custom properties of the tileset
-	Properties []Property `xml:"properties>property"`
+	Properties []Property `xml:"properties,omitempty>property"`
 	// Image is the image associated with the tileset
 	Image []Image `xml:"image"`
 	// TerrainTypes are the terraintypes associated with the tileset
-	TerrainTypes []Terrain `xml:"terraintypes>terrain"`
+	TerrainTypes []Terrain `xml:"terraintypes,omitempty>terrain"`
 	// Tiles are tiles in the tileset
 	Tiles []Tile `xml:"tile"`
 	// WangSets contain the list of wang sets defined for this tileset
-	WangSets []WangSet `xml:"wangsets>wangset"`
+	WangSets []WangSet `xml:"wangsets,omitempty>wangset"`
 }
 
 // TileOffset is used to specify an offset in pixels, to be applied when
@@ -73,13 +73,13 @@ type Grid struct {
 type Image struct {
 	// Format is used for embedded images, in combination with a data child element.
 	// Valid values are file extensions like png, gif, jpg, bmp, etc.
-	Format string `xml:"format,attr"`
+	Format string `xml:"format,attr,omitempty"`
 	// Source is the reference to the tileset image file.
 	Source string `xml:"source,attr"`
 	// Transparent defines a specific color that is treated as transparent (example
 	// value: “#FF00FF” for magenta). Up until Tiled 0.12, this value is written
 	// out without a # but this is planned to change.
-	Transparent string `xml:"trans,attr"`
+	Transparent string `xml:"trans,attr,omitempty"`
 	// Width is the image width in pixels
 	Width float64 `xml:"width,attr"`
 	// Height is the image height in pixels


### PR DESCRIPTION
Also, add `XMLName` field to `Map` to specify that the `<map>` tag should be lowercase. Without this change, using `encoding/xml.Marshal` would produce maps that cannot be loaded in Tiled, since they would include a titlecased `<Map>` tag instead.

With this change, it is possible to use `encoding.Marshal` on a given `tmx.Map` to produce valid TMX output that loads successfully in Tiled.