### PR TITLE
Parse multiline property values

### DIFF
--- a/object_test.go
+++ b/object_test.go
@@ -207,3 +207,34 @@ func TestTextMalformed(t *testing.T) {
 		return
 	}
 }
+
+func TestPropertyParsed(t *testing.T) {
+	TMXURL = "testData/properties.tmx"
+	f, err := os.Open(TMXURL)
+	if err != nil {
+		t.Errorf("Unable to open %v. Error was: %v", TMXURL, err)
+		return
+	}
+	defer f.Close()
+	m, err := Parse(f)
+	if err != nil {
+		t.Error("Unable to parse object data")
+	}
+	prop1 := m.ObjectGroups[0].Objects[0].Properties[0]
+	if prop1.Name != "attrValue" {
+		t.Error("Unable to parse object name")
+	}
+	if prop1.Value != "This is an attribute value" {
+		t.Error("Unable to parse object value")
+	}
+
+	prop2 := m.ObjectGroups[0].Objects[0].Properties[1]
+	if prop2.Name != "multilineValue" {
+		t.Error("Unable to parse object name")
+	}
+	if prop2.Value != `This is
+a multiline value` {
+		t.Error("Unable to parse object value")
+	}
+
+}

--- a/property.go
+++ b/property.go
@@ -1,5 +1,7 @@
 package tmx
 
+import "encoding/xml"
+
 // Property is any custom data added to elements of the map
 type Property struct {
 	// Name is the name of the property
@@ -9,4 +11,31 @@ type Property struct {
 	Type string `xml:"type,attr"`
 	// Value is the value of the property
 	Value string `xml:"value,attr"`
+}
+
+func (p *Property) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	prop := struct {
+		// Name is the name of the property
+		Name string `xml:"name,attr"`
+		// Type is the type of the property. It can be string, int, float, bool,
+		// color or file
+		Type string `xml:"type,attr"`
+		// Value is the value of the property
+		Value string `xml:"value,attr"`
+
+		CharData string `xml:",chardata"`
+	}{}
+	if err := d.DecodeElement(&prop, &start); err != nil {
+		return err
+	}
+
+	p.Name = prop.Name
+	p.Type = prop.Type
+	p.Value = prop.Value
+	if len(p.Value) == 0 {
+		p.Value = prop.CharData
+	}
+
+	return nil
+
 }

--- a/testData/properties.tmx
+++ b/testData/properties.tmx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.0" tiledversion="1.1.5" orientation="orthogonal" renderorder="right-down" width="3" height="3" tilewidth="16" tileheight="16" infinite="0" nextobjectid="8">
+ <tileset firstgid="1" name="roguelikeHoliday_transparent" tilewidth="16" tileheight="16" spacing="1" tilecount="48" columns="12">
+  <image source="roguelikeHoliday_transparent.png" width="203" height="67"/>
+ </tileset>
+ <layer name="Tile Layer 1" width="3" height="3">
+  <data encoding="base64" compression="zlib">
+   eJxTZWBgUAdiNSRaFYkGYQAa1AFV
+  </data>
+ </layer>
+ <objectgroup name="Object Layer 1">
+  <object id="1" name="Rectangle" x="10" y="13" width="25" height="23">
+    <properties>
+      <property name="attrValue" value="This is an attribute value"/>
+      <property name="multilineValue">This is
+a multiline value</property>
+    </properties>
+  </object>
+
+ </objectgroup>
+</map>


### PR DESCRIPTION
As stated on https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#properties the tmx file can contain properties, which have their values stored as chardata and not in the `value` attribute.

So I've added a test case for this problem and a potential solution.